### PR TITLE
Dodanie brakujących kontrolerów

### DIFF
--- a/dotpay.php
+++ b/dotpay.php
@@ -39,6 +39,7 @@ class dotpay extends PaymentModule
 		$this->tab = 'payments_gateways';
 		$this->version = '1.5.2';
                 $this->author = 'tech@dotpay.pl';
+                $this->controllers = array('payment', 'callback');
 
 		parent::__construct();
 


### PR DESCRIPTION
Ze względu na ich brak nie było mozna ustawiać kolumn dla płatności