### PR TITLE
Ensure extra charge virtual product availability

### DIFF
--- a/controllers/front/preparing.php
+++ b/controllers/front/preparing.php
@@ -50,7 +50,24 @@ class dotpaypreparingModuleFrontController extends DotpayController {
                 if($productId != 0) {
                     $product = new Product($productId, true);
                     $product->price = $exAmount;
+                    $product->id = $productId;
+                    $product->name = array((int)Configuration::get('PS_LANG_DEFAULT') => 'Online payment');
+                    $product->link_rewrite = array((int)Configuration::get('PS_LANG_DEFAULT') => 'online-payment');
+                    $product->visibility = 'none';
+                    $product->reference = 'DOTPAYFEE';
+                    $product->is_virtual = 1;
+                    $product->online_only = 1;
+                    $product->redirect_type = '404';
+                    $product->quantity = 99999;
+                    $product->id_tax_rules_group = 0;
+                    $product->active = 1;
+                    $product->available_for_order = 1;
+                    $product->meta_keywords = 'payment';
+                    $product->id_category = 1;
+                    $product->id_category_default = 1;
+                    $product->addToCategories(array(1));
                     $product->save();
+                    StockAvailable::setQuantity($product->id,NULL,$product->quantity);
                     $product->flushPriceCache();
 
                     $this->context->cart->updateQty(1, $product->id);


### PR DESCRIPTION
Fixes possible bugs in multistore configuration caused by empty link_rewrite, name, available_for_order and more.

There were some bugs in current module version which causes 500 error when multistore configuration is activated.
In order to reproduce this bugs install and activate module in normal single store and then add multistore.