### PR TITLE
Update dotpay.php

### DIFF
--- a/controllers/front/dotpay.php
+++ b/controllers/front/dotpay.php
@@ -193,12 +193,7 @@ abstract class DotpayController extends ModuleFrontController
         if ($this->currencyId === null) {
             $this->currencyId = $this->context->cart->id_currency;
         }
-        return $this->api->getFormatAmount(
-            Tools::displayPrice(
-                $this->totalAmount,
-                new Currency($this->currencyId)
-            )
-        );
+        return $this->api->getFormatAmount($this->totalAmount);
     }
     
     /**
@@ -213,12 +208,7 @@ abstract class DotpayController extends ModuleFrontController
         if ($this->currencyId === null) {
             $this->currencyId = $this->context->cart->id_currency;
         }
-        return $this->api->getFormatAmount(
-            Tools::displayPrice(
-                $this->shippingAmount,
-                new Currency($this->currencyId)
-            )
-        );
+        return $this->api->getFormatAmount($this->shippingAmount);
     }
     
     /**


### PR DESCRIPTION
Metody getDotAmount() i getDotShippingAmount() zwracają złą cenę jeżeli jest ona w powyżej 1000 i w formacie z separacją tysięcy. 
Dla kwoty 1 050 zwracany jest wynik 1. 
Błąd jest dlatego, że getFormatAmount ma przyjąć liczbę a przyjmuje 1 050PLN.

Wersja PS: 1.6.1.11 po migracji z 1.3. Moduł Dotpay instalowany z GIT po pobraniu wersji zip: 2.2.7.2